### PR TITLE
removed leading http from fonts ref link

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -162,23 +162,26 @@ sub {
 /* Paragraphs. */
 
 .article p {
-    line-height: 1.3em;
+    line-height: 2.0em;
     margin-bottom: 1.5em;
 }
 
 /* Headers. */
 
 .article h1 {
+    line-height: 2.0em;
     padding-bottom: 1em;
     font-size: 1.4em;
 }
 
 .article h2 {
+    line-height: 2.0em;
     padding-bottom: 0.9em;
     font-size: 1.2em;
 }
 
 .article h3 {
+    line-height: 2.0em
     padding-bottom: 0.8em;
     font-size: 1em;
 }
@@ -201,7 +204,7 @@ sub {
 /* Blockquotes */
 
 .article blockquote {
-    font-size: 0.9em;
+    font-size: 0.7em;
     font-style: italic;
     border-left: 3px solid #ccc;
     margin-left: 30px;
@@ -223,7 +226,7 @@ sub {
 
 .article pre {
     font-family: 'Source Code Pro';
-    font-size: .8em;
+    font-size: 0.7em;
     margin: auto;
     padding: 1em;
     line-height: 120%;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -162,26 +162,23 @@ sub {
 /* Paragraphs. */
 
 .article p {
-    line-height: 2.0em;
+    line-height: 1.3em;
     margin-bottom: 1.5em;
 }
 
 /* Headers. */
 
 .article h1 {
-    line-height: 2.0em;
     padding-bottom: 1em;
     font-size: 1.4em;
 }
 
 .article h2 {
-    line-height: 2.0em;
     padding-bottom: 0.9em;
     font-size: 1.2em;
 }
 
 .article h3 {
-    line-height: 2.0em
     padding-bottom: 0.8em;
     font-size: 1em;
 }
@@ -204,7 +201,7 @@ sub {
 /* Blockquotes */
 
 .article blockquote {
-    font-size: 0.7em;
+    font-size: 0.9em;
     font-style: italic;
     border-left: 3px solid #ccc;
     margin-left: 30px;
@@ -226,7 +223,7 @@ sub {
 
 .article pre {
     font-family: 'Source Code Pro';
-    font-size: 0.7em;
+    font-size: .8em;
     margin: auto;
     padding: 1em;
     line-height: 120%;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -162,26 +162,26 @@ sub {
 /* Paragraphs. */
 
 .article p {
-    line-height: 1.5em;
+    line-height: 2.0em;
     margin-bottom: 1.5em;
 }
 
 /* Headers. */
 
 .article h1 {
-    line-height: 1.5em;
+    line-height: 2.0em;
     padding-bottom: 1em;
     font-size: 1.4em;
 }
 
 .article h2 {
-    line-height: 1.5em;
+    line-height: 2.0em;
     padding-bottom: 0.9em;
     font-size: 1.2em;
 }
 
 .article h3 {
-    line-height: 1.5em
+    line-height: 2.0em
     padding-bottom: 0.8em;
     font-size: 1em;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -162,26 +162,26 @@ sub {
 /* Paragraphs. */
 
 .article p {
-    line-height: 2.0em;
+    line-height: 1.5em;
     margin-bottom: 1.5em;
 }
 
 /* Headers. */
 
 .article h1 {
-    line-height: 2.0em;
+    line-height: 1.5em;
     padding-bottom: 1em;
     font-size: 1.4em;
 }
 
 .article h2 {
-    line-height: 2.0em;
+    line-height: 1.5em;
     padding-bottom: 0.9em;
     font-size: 1.2em;
 }
 
 .article h3 {
-    line-height: 2.0em
+    line-height: 1.5em
     padding-bottom: 0.8em;
     font-size: 1em;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,9 +4,9 @@
   <head>
     {% block head %}
       <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,400,600,700' rel='stylesheet' type='text/css' />
-      <link href='http://fonts.googleapis.com/css?family=Merriweather:300' rel='stylesheet' type='text/css'/>
-      <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:200,400,700' rel='stylesheet' type='text/css'/>
+      <link href='//fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,700italic,400,600,700' rel='stylesheet' type='text/css' />
+      <link href='//fonts.googleapis.com/css?family=Merriweather:300' rel='stylesheet' type='text/css'/>
+      <link href='//fonts.googleapis.com/css?family=Source+Code+Pro:200,400,700' rel='stylesheet' type='text/css'/>
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/icons.css"/>
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/styles.css"/>
       <meta charset="utf-8" />


### PR DESCRIPTION
Hey there,
I love your theme but struggled to get it working if hosting on github.
With some help, I figured out the cause was github insisting on using https. Once this is removed from the base.html fonts references, it all works great.
Thanks for the theme!
Tina
