### PR TITLE
create invisible rel=me links in the header and in social media links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,9 +10,20 @@
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/icons.css"/>
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/styles.css"/>
       <meta charset="utf-8" />
-      {% for title, link in SOCIAL %}
-      <link class="u-url" rel="me" href="{{ link }}"/>
-      {% endfor %}
+      {% if USE_INDIEAUTH %}
+      	{% for title, link in SOCIAL %}
+      	<link rel="me" href="{{ link }}"/>
+      	{% endfor %}
+	{% if GITHUB_ADDRESS %}
+	<link rel="me" href="{{ GITHUB_ADDRESS }}" />
+	{% endif %}
+	{% if TWITTER_ADDRESS %}
+	<link rel="me" href="{{ TWITTER_ADDRESS }}" />
+	{% endif %}
+	{% if INSTAGRAM_ADDRESS %}
+	<link rel="me" href="{{ INSTAGRAM_ADDRESS }}" />
+	{% endif %}
+      {% endif %}
       {% if FEED_ATOM %}
         <link href="/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
       {% endif %}
@@ -55,16 +66,16 @@
               <li><a class="nodec icon-mail-alt" href="mailto:{{ EMAIL_ADDRESS }}"></a></li>
             {% endif %}
             {% if GITHUB_ADDRESS %}
-              <li><a class="nodec icon-github" rel="me" href="{{ GITHUB_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-github" href="{{ GITHUB_ADDRESS }}"></a></li>
             {% endif %}
             {% if SO_ADDRESS %}
-              <li><a class="nodec icon-stackoverflow" rel="me" href="{{ SO_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-stackoverflow"  href="{{ SO_ADDRESS }}"></a></li>
             {% endif %}
             {% if TWITTER_ADDRESS %}
-              <li><a class="nodec icon-twitter" rel="me" href="{{ TWITTER_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-twitter"  href="{{ TWITTER_ADDRESS }}"></a></li>
             {% endif %}
             {% if FB_ADDRESS %}
-              <li><a class="nodec icon-facebook" rel="me" href="{{ FB_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-facebook" href="{{ FB_ADDRESS }}"></a></li>
             {% endif %}
             {% if FEED_RSS %}
               <li><a class="nodec icon-rss" href="/{{ FEED_RSS }}"></a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,16 +55,16 @@
               <li><a class="nodec icon-mail-alt" href="mailto:{{ EMAIL_ADDRESS }}"></a></li>
             {% endif %}
             {% if GITHUB_ADDRESS %}
-              <li><a class="nodec icon-github" href="{{ GITHUB_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-github" rel="me" href="{{ GITHUB_ADDRESS }}"></a></li>
             {% endif %}
             {% if SO_ADDRESS %}
-              <li><a class="nodec icon-stackoverflow" href="{{ SO_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-stackoverflow" rel="me" href="{{ SO_ADDRESS }}"></a></li>
             {% endif %}
             {% if TWITTER_ADDRESS %}
-              <li><a class="nodec icon-twitter" href="{{ TWITTER_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-twitter" rel="me" href="{{ TWITTER_ADDRESS }}"></a></li>
             {% endif %}
             {% if FB_ADDRESS %}
-              <li><a class="nodec icon-facebook" href="{{ FB_ADDRESS }}"></a></li>
+              <li><a class="nodec icon-facebook" rel="me" href="{{ FB_ADDRESS }}"></a></li>
             {% endif %}
             {% if FEED_RSS %}
               <li><a class="nodec icon-rss" href="/{{ FEED_RSS }}"></a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,9 @@
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/icons.css"/>
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/styles.css"/>
       <meta charset="utf-8" />
+      {% for title, link in SOCIAL %}
+      <a class="nodec" rel="me" href="{{ link }}"></a>
+      {% endfor %}
       {% if FEED_ATOM %}
         <link href="/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />
       {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
       <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/styles.css"/>
       <meta charset="utf-8" />
       {% for title, link in SOCIAL %}
-      <a class="nodec" rel="me" href="{{ link }}"></a>
+      <link class="u-url" rel="me" href="{{ link }}"/>
       {% endfor %}
       {% if FEED_ATOM %}
         <link href="/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />


### PR DESCRIPTION
Making crowsfoot IndieWeb compliant by taking social media links from pelican configuration file and putting them into the header, with rel="me" attribute. This doesn't affect the look of this theme in any way. An example website with such invisible links is https://masoud.abkenar.net/ and more information can be found in https://indiewebify.me/